### PR TITLE
Initial release

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,47 @@
+name: Zephyr Docker Image CI
+run-name: Here we build the Docker image used to build our Rovertito application 🚀
+on: [push]
+jobs:
+  build-and-publish-develop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ghcr.io/spacebee-technologies/zephyr-environment:develop
+  build-and-publish-tags:
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: |
+            ghcr.io/spacebee-technologies/zephyr-environment:latest
+            ghcr.io/spacebee-technologies/zephyr-environment:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:20.04
+
+# Configuration
+ARG ZEPHYR_SDK_VERSION=0.15.1
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="${PATH}:/root/.local/bin"
+ENV ZEPHYR_BASE=/root/zephyrproject/zephyr
+
+# Basic dependencies
+RUN apt-get update && apt-get install -y wget apt-transport-https gpg udev
+
+# Install OS dependencies
+WORKDIR /tmp
+RUN wget https://apt.kitware.com/kitware-archive.sh
+RUN bash kitware-archive.sh
+RUN apt-get install -y --no-install-recommends \
+        git cmake ninja-build gperf ccache dfu-util device-tree-compiler \
+        python3-dev python3-pip python3-setuptools python3-tk python3-wheel \
+        xz-utils file make gcc gcc-multilib g++-multilib libsdl2-dev libmagic1
+
+# Install Zephyr
+WORKDIR /root/zephyrproject
+RUN pip3 install --user -U west
+RUN west init /root/zephyrproject
+RUN west update
+RUN west zephyr-export
+RUN pip3 install --user -r /root/zephyrproject/zephyr/scripts/requirements.txt
+
+# Install Zephyr SDK
+WORKDIR /tmp
+ARG ZEPHYR_SDK_DOWNLOAD_URL=https://github.com/zephyrproject-rtos/sdk-ng/releases/download
+RUN wget "${ZEPHYR_SDK_DOWNLOAD_URL}/v${ZEPHYR_SDK_VERSION}/zephyr-sdk-${ZEPHYR_SDK_VERSION}_linux-x86_64.tar.gz"
+RUN wget -O - "${ZEPHYR_SDK_DOWNLOAD_URL}/v${ZEPHYR_SDK_VERSION}/sha256.sum" | shasum --check --ignore-missing
+RUN tar xvf "zephyr-sdk-${ZEPHYR_SDK_VERSION}_linux-x86_64.tar.gz" -C /root
+WORKDIR "/root/zephyr-sdk-${ZEPHYR_SDK_VERSION}"
+RUN ./setup.sh -t all -h -c
+
+WORKDIR /workspace

--- a/scripts/linux_build.sh
+++ b/scripts/linux_build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+readonly PROJECT_DIRECTORY="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && cd .. && pwd)"
+readonly IMAGE_NAME='zephyr-environment'
+
+docker build \
+  -f "${PROJECT_DIRECTORY}/Dockerfile" \
+  -t "${IMAGE_NAME}" \
+  "${PROJECT_DIRECTORY}"

--- a/scripts/linux_run.sh
+++ b/scripts/linux_run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+readonly IMAGE_NAME='zephyr-environment'
+
+docker run \
+  --privileged \
+  --rm \
+  -t \
+  -i \
+  -v /dev:/dev \
+  "${IMAGE_NAME}"


### PR DESCRIPTION
Adding a Docker image for Zephyr development. The image is built in a GitHub workflow and published to GitHub Container registry and should be used to:
- build Zephyr applications,
- debug and
- flash binary into MCU.
